### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ RUST_LOG=info \
     --package counter-nats
 ```
 
-Notice that you can change the configuration either by changing the `defaul.yaml` file at `examples/counter-nats/config` or by overriding the configuration settings with environment variables, e.g. `APP__COUNTER__EVT_COUNT=42`:
+Notice that you can change the configuration either by changing the `defaul.toml` file at `examples/counter-nats/config` or by overriding the configuration settings with environment variables, e.g. `APP__COUNTER__EVT_COUNT=42`:
 
 ```
 RUST_LOG=info \
@@ -179,7 +179,7 @@ Make sure you know the following connection parameters:
 - password
 - dbname
 
-Change the configuration either by changing the `defaul.yaml` file at `examples/counter-postgres/config` or by overriding the configuration settings with environment variables, e.g. `APP__EVT_LOG__DBNAME=test` or `APP__COUNTER__EVT_COUNT=42`:
+Change the configuration either by changing the `defaul.toml` file at `examples/counter-postgres/config` or by overriding the configuration settings with environment variables, e.g. `APP__EVT_LOG__DBNAME=test` or `APP__COUNTER__EVT_COUNT=42`:
 
 Then use the following command to run the example:
 


### PR DESCRIPTION
The readme refers to yaml config files but the files in the repo are toml files