### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ RUST_LOG=info \
     --package counter-nats
 ```
 
-Notice that you can change the configuration either by changing the `defaul.yaml` file at `examples/counter-nats/config` or by overriding the configuration settings with environment variables, e.g. `APP__COUNTER__EVT_COUNT=42`:
+Notice that you can change the configuration either by changing the `defaul.toml` file at `examples/counter-nats/config` or by overriding the configuration settings with environment variables, e.g. `APP__COUNTER__EVT_COUNT=42`:
 
 ```
 RUST_LOG=info \
@@ -179,7 +179,7 @@ Make sure you know the following connection parameters:
 - password
 - dbname
 
-Change the configuration either by changing the `defaul.yaml` file at `examples/counter-postgres/config` or by overriding the configuration settings with environment variables, e.g. `APP__EVT_LOG__DBNAME=test` or `APP__COUNTER__EVT_COUNT=42`:
+Change the configuration either by changing the `default.toml` file at `examples/counter-postgres/config` or by overriding the configuration settings with environment variables, e.g. `APP__EVT_LOG__DBNAME=test` or `APP__COUNTER__EVT_COUNT=42`:
 
 Then use the following command to run the example:
 

--- a/eventsourced-nats/src/lib.rs
+++ b/eventsourced-nats/src/lib.rs
@@ -3,7 +3,6 @@
 
 #![allow(incomplete_features)]
 #![feature(async_fn_in_trait)]
-#![feature(nonzero_min_max)]
 #![feature(return_position_impl_trait_in_trait)]
 
 mod evt_log;
@@ -22,7 +21,7 @@ use thiserror::Error;
 pub enum Error {
     /// The connection to the NATS server cannot be established.
     #[error("Cannot connect to NATS server")]
-    Connect(#[from] std::io::Error),
+    Connect(#[from] async_nats::ConnectError),
 
     /// An event cannot be published.
     #[error("Cannot publish events")]

--- a/eventsourced-postgres/src/evt_log.rs
+++ b/eventsourced-postgres/src/evt_log.rs
@@ -239,7 +239,7 @@ impl EvtLog for PostgresEvtLog {
                 }
 
                 // Only sleep if requesting future events.
-                if (Some(current_from_seq_no) >= last_seq_no) {
+                if Some(current_from_seq_no) >= last_seq_no {
                     sleep(self.poll_interval).await;
                 }
             }
@@ -304,7 +304,7 @@ impl EvtLog for PostgresEvtLog {
                 }
 
                 // Only sleep if requesting future events.
-                if (current_from_seq_no >= last_seq_no) {
+                if current_from_seq_no >= last_seq_no {
                     sleep(self.poll_interval).await;
                 }
             }

--- a/eventsourced-postgres/src/lib.rs
+++ b/eventsourced-postgres/src/lib.rs
@@ -3,7 +3,6 @@
 
 #![allow(incomplete_features)]
 #![feature(async_fn_in_trait)]
-#![feature(nonzero_min_max)]
 #![feature(return_position_impl_trait_in_trait)]
 
 mod evt_log;

--- a/eventsourced/src/lib.rs
+++ b/eventsourced/src/lib.rs
@@ -3,7 +3,6 @@
 #![allow(clippy::type_complexity)]
 #![allow(incomplete_features)]
 #![feature(async_fn_in_trait)]
-#![feature(nonzero_min_max)]
 #![feature(return_position_impl_trait_in_trait)]
 #![feature(type_alias_impl_trait)]
 


### PR DESCRIPTION
The README refers to yaml files in a couple of places but these are toml files