### PR TITLE
initial implementation of replies for commands

### DIFF
--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -45,20 +45,22 @@ where
                 if n > 0 && n % 2_500 == 0 {
                     println!("{id}: {} events persisted", n * 2);
                 }
-                counter
-                    .handle_cmd(Cmd::Inc(n as u64))
+                let res1 = counter
+                    .ask(|r| Cmd::Inc(n as u64, r))
                     .await
                     .context("send/receive Inc command")
                     .unwrap()
                     .context("handle Inc command")
                     .unwrap();
-                counter
-                    .handle_cmd(Cmd::Dec(n as u64))
+                let res2 = counter
+                    .ask(|r| Cmd::Dec(n as u64, r))
                     .await
                     .context("send/receive Dec command")
                     .unwrap()
                     .context("handle Dec command")
                     .unwrap();
+
+                println!("{id}: Inc result: {}, Dec result: {}", res1, res2);
             }
         });
     }


### PR DESCRIPTION
Idea:

 * Commands that want a reply need to add a `Reply<T>` field annotating the type of reply they want to provide and than can be used to construct the reply.
 * new `EntityRef::ask` will help if a reply is needed
 * What to do about commands that do not require a reply? I wouldn't want to force them to add a `Reply<()>` as well, but that means that we will have to support to different ways of dealing with a command: with reply and without reply. This adds a small potential for runtime errors i.e. a handler could forget to use the reply.
 * On the other hand, we could enforce the reply style for all commands which could force you to specify a full type like `Result` to both deal with user replies and errors.