### PR TITLE
feat: create replies directly out of handle_cmd using closure

### DIFF
--- a/eventsourced/src/lib.rs
+++ b/eventsourced/src/lib.rs
@@ -83,7 +83,7 @@ pub trait EventSourced {
     const TYPE_NAME: &'static str;
 
     /// The event handler.
-    fn handle_evt(self, evt: &Self::Evt) -> Self;
+    fn handle_evt(self, evt: Self::Evt) -> Self;
 }
 
 /// A command for a [EventSourced] implementation, defining command handling and replying.
@@ -272,7 +272,7 @@ where
                         .map(|&(seq_no, _)| seq_no >= to_seq_no)
                         .unwrap_or(true)
                 })
-                .try_fold(state, |state, (_, evt)| ok(state.handle_evt(&evt)))
+                .try_fold(state, |state, (_, evt)| ok(state.handle_evt(evt)))
                 .await?;
 
             debug!(?id, state = ?state, "replayed evts");
@@ -307,7 +307,7 @@ where
                                     debug!(?id, ?evt, seq_no, "persited event");
 
                                     last_seq_no = Some(seq_no);
-                                    state = state.handle_evt(&evt);
+                                    state = state.handle_evt(evt);
 
                                     evt_count += 1;
                                     if snapshot_after
@@ -437,7 +437,7 @@ mod tests {
 
         const TYPE_NAME: &'static str = "counter";
 
-        fn handle_evt(self, evt: &CounterEvt) -> Self {
+        fn handle_evt(self, evt: CounterEvt) -> Self {
             match evt {
                 CounterEvt::Increased(_, n) => Self(self.0 + n),
                 CounterEvt::Decreased(_, n) => Self(self.0 - n),

--- a/eventsourced/src/lib.rs
+++ b/eventsourced/src/lib.rs
@@ -97,8 +97,8 @@ where
     type Error: Send + 'static;
 
     /// The command handler, taking this command, and references to the ID and the state of
-    /// the event sourced entity, either rejecting this command via [CmdEffect::reject] or returning an
-    /// event using [CmdEffect::emit_and_reply] (or [CmdEffect::emit] in case Reply = ())).
+    /// the event sourced entity, either rejecting this command via [CmdEffect::reject] or returning
+    /// an event using [CmdEffect::emit_and_reply] (or [CmdEffect::emit] in case Reply = ())).
     fn handle_cmd(self, id: &E::Id, state: &E) -> CmdEffect<E, Self::Reply, Self::Error>;
 }
 
@@ -483,7 +483,10 @@ mod tests {
             } else {
                 CmdEffect::emit_and_reply(
                     CounterEvt::Decreased(*id, self.0),
-                    move |state: &Counter| state.0 + self.0 - self.0, /* Simple no-op test to verify that closing over this cmd is possible */
+                    move |state: &Counter| state.0 + self.0 - self.0, /* Simple no-op test to
+                                                                       * verify that closing
+                                                                       * over this cmd is
+                                                                       * possible */
                 )
             }
         }

--- a/eventsourced/src/lib.rs
+++ b/eventsourced/src/lib.rs
@@ -97,7 +97,8 @@ where
     fn handle_cmd(&self, id: &E::Id, state: &E) -> CmdEffect<E, Self::Reply, Self::Error>;
 }
 
-/// The result of handling a command, either emitting an event and replying or rejecting the command.
+/// The result of handling a command, either emitting an event and replying or rejecting the
+/// command.
 pub enum CmdEffect<E, Reply, Error>
 where
     E: EventSourced,

--- a/eventsourced/src/lib.rs
+++ b/eventsourced/src/lib.rs
@@ -377,6 +377,7 @@ where
     Self: Debug,
     E: EventSourced,
 {
+    #[allow(clippy::type_complexity)] // internal type, who cares?
     fn handle_cmd(
         &self,
         id: &E::Id,

--- a/eventsourced/src/lib.rs
+++ b/eventsourced/src/lib.rs
@@ -97,8 +97,8 @@ where
     type Error: Send + 'static;
 
     /// The command handler, taking this command, and references to the ID and the state of
-    /// the event sourced entity, either rejecting this command via [Self::Error] or returning an
-    /// event.
+    /// the event sourced entity, either rejecting this command via [CmdEffect::reject] or returning an
+    /// event using [CmdEffect::emit_and_reply] (or [CmdEffect::emit] in case Reply = ())).
     fn handle_cmd(self, id: &E::Id, state: &E) -> CmdEffect<E, Self::Reply, Self::Error>;
 }
 
@@ -128,6 +128,16 @@ where
     /// Reject this command with the given error.
     pub fn reject(error: Error) -> Self {
         Self::Reject(error)
+    }
+}
+
+impl<E, Error> CmdEffect<E, (), Error>
+where
+    E: EventSourced,
+{
+    /// Persist the given event (and don't give a reply for Cmds with Reply = ()).
+    pub fn emit(evt: E::Evt) -> Self {
+        Self::emit_and_reply(evt, |_| ())
     }
 }
 

--- a/eventsourced/src/lib.rs
+++ b/eventsourced/src/lib.rs
@@ -61,11 +61,13 @@ use tokio::{
 use tracing::{debug, error, instrument};
 
 type BoxedCmd<E> = Box<dyn ErasedCmd<E> + Send>;
-#[allow(type_alias_bounds)]
-type BoxedCmdEffect<E>
-where
-    E: EventSourced,
-= Result<(E::Evt, Box<dyn FnOnce(&E) -> BoxedAny + Send + Sync>), BoxedAny>;
+type BoxedCmdEffect<E> = Result<
+    (
+        <E as EventSourced>::Evt,
+        Box<dyn FnOnce(&E) -> BoxedAny + Send + Sync>,
+    ),
+    BoxedAny,
+>;
 type BoxedAny = Box<dyn Any + Send>;
 type BoxedMsg<E> = (BoxedCmd<E>, oneshot::Sender<Result<BoxedAny, BoxedAny>>);
 

--- a/examples/counter/src/counter.rs
+++ b/examples/counter/src/counter.rs
@@ -32,7 +32,7 @@ impl Cmd<Counter> for IncreaseCounter {
     type Error = Overflow;
     type Reply = u64;
 
-    fn handle_cmd(&self, id: &Uuid, state: &Counter) -> CmdEffect<Counter, u64, Overflow> {
+    fn handle_cmd(self, id: &Uuid, state: &Counter) -> CmdEffect<Counter, u64, Overflow> {
         if u64::MAX - state.0 < self.0 {
             CmdEffect::reject(Overflow)
         } else {
@@ -53,7 +53,7 @@ impl Cmd<Counter> for DecreaseCounter {
     type Error = Underflow;
     type Reply = u64;
 
-    fn handle_cmd(&self, id: &Uuid, state: &Counter) -> CmdEffect<Counter, u64, Underflow> {
+    fn handle_cmd(self, id: &Uuid, state: &Counter) -> CmdEffect<Counter, u64, Underflow> {
         if state.0 < self.0 {
             CmdEffect::reject(Underflow)
         } else {

--- a/examples/counter/src/counter.rs
+++ b/examples/counter/src/counter.rs
@@ -11,7 +11,7 @@ impl EventSourced for Counter {
 
     const TYPE_NAME: &'static str = "counter";
 
-    fn handle_evt(self, evt: &CounterEvt) -> Self {
+    fn handle_evt(self, evt: CounterEvt) -> Self {
         match evt {
             CounterEvt::Increased(_, n) => Self(self.0 + n),
             CounterEvt::Decreased(_, n) => Self(self.0 - n),


### PR DESCRIPTION
We discussed a similar solution before in https://github.com/hseeberger/eventsourced/pull/201#discussion_r1530031173

It now came up again that `make_reply` is hard to use when you need access to the event. In that case the previous solution required manual correlation of the event created in `handle_cmd` with the event passed to `make_reply`. The only way would to unpack the right event type would be to panic on all the other event cases which is inconvenient (in simple cases) and a potential for runtime panics (in more complex cases).

/cc @qrilka 