### PR TITLE
chore: standardize project scaffolding and package metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-.claude
 .DS_Store
+.claude
+.envrc.local
 .vscode
 .zed
 target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,17 @@
 [workspace]
 members = [
-  "eventsourced",
-  "eventsourced-nats",
-  "eventsourced-postgres",
-  "eventsourced-projection",
-  "examples/counter",
-  "examples/counter-nats",
-  "examples/counter-postgres",
+    "eventsourced",
+    "eventsourced-nats",
+    "eventsourced-postgres",
+    "eventsourced-projection",
+    "examples/counter",
+    "examples/counter-nats",
+    "examples/counter-postgres",
 ]
 resolver = "2"
 
 [workspace.package]
 edition    = "2024"
-authors    = [ "Heiko Seeberger <git@heikoseeberger.de>" ]
 license    = "Apache-2.0"
 homepage   = "https://github.com/hseeberger/eventsourced"
 repository = "https://github.com/hseeberger/eventsourced"

--- a/eventsourced-nats/Cargo.toml
+++ b/eventsourced-nats/Cargo.toml
@@ -2,13 +2,13 @@
 name          = "eventsourced-nats"
 description   = "NATS implementation for EventSourced EventLog and SnapshotStore."
 version       = "0.15.1"
-readme        = "README.md"
 edition       = { workspace = true }
-authors       = { workspace = true }
 license       = { workspace = true }
+readme        = "README.md"
 homepage      = { workspace = true }
 repository    = { workspace = true }
-documentation = "https://docs.rs/eventsourced-nats/latest/eventsourced-nats"
+documentation = "https://docs.rs/eventsourced-nats/latest/eventsourced_nats/"
+publish       = true
 
 [dependencies]
 eventsourced = { path = "../eventsourced", version = "0.27.0" }
@@ -24,12 +24,12 @@ tokio        = { workspace = true }
 tracing      = { workspace = true }
 
 [dev-dependencies]
-assert_matches         = { workspace = true }
-config                 = { workspace = true }
-eventsourced           = { path = "../eventsourced", version = "0.27.0", features = [ "serde_json" ] }
-testcontainers         = { workspace = true }
-tokio                  = { workspace = true, features = [ "macros" ] }
-uuid                   = { workspace = true }
+assert_matches = { workspace = true }
+config         = { workspace = true }
+eventsourced   = { path = "../eventsourced", version = "0.27.0", features = [ "serde_json" ] }
+testcontainers = { workspace = true }
+tokio          = { workspace = true, features = [ "macros" ] }
+uuid           = { workspace = true }
 
 [build-dependencies]
 anyhow      = { workspace = true }

--- a/eventsourced-postgres/Cargo.toml
+++ b/eventsourced-postgres/Cargo.toml
@@ -2,13 +2,13 @@
 name          = "eventsourced-postgres"
 description   = "Postgres implementation for EventSourced EventLog and SnapshotStore."
 version       = "0.14.1"
-readme        = "README.md"
 edition       = { workspace = true }
-authors       = { workspace = true }
 license       = { workspace = true }
+readme        = "README.md"
 homepage      = { workspace = true }
 repository    = { workspace = true }
-documentation = "https://docs.rs/eventsourced-postgres/latest/eventsourced-postgres"
+documentation = "https://docs.rs/eventsourced-postgres/latest/eventsourced_postgres/"
+publish       = true
 
 [dependencies]
 eventsourced    = { path = "../eventsourced", version = "0.27.0" }

--- a/eventsourced-projection/Cargo.toml
+++ b/eventsourced-projection/Cargo.toml
@@ -2,13 +2,13 @@
 name          = "eventsourced-projection"
 description   = "Projections for EventSourced."
 version       = "0.6.1"
-readme        = "README.md"
 edition       = { workspace = true }
-authors       = { workspace = true }
 license       = { workspace = true }
+readme        = "README.md"
 homepage      = { workspace = true }
 repository    = { workspace = true }
-documentation = "https://docs.rs/eventsourced-nats/latest/eventsourced-projection"
+documentation = "https://docs.rs/eventsourced-projection/latest/eventsourced_projection/"
+publish       = true
 
 [dependencies]
 eventsourced  = { path = "../eventsourced", version = "0.27.0", features = [ "serde_json" ] }

--- a/eventsourced/Cargo.toml
+++ b/eventsourced/Cargo.toml
@@ -2,13 +2,13 @@
 name          = "eventsourced"
 description   = "Event sourced entities in Rust."
 version       = "0.27.0"
-readme        = "README.md"
 edition       = { workspace = true }
-authors       = { workspace = true }
 license       = { workspace = true }
+readme        = "README.md"
 homepage      = { workspace = true }
 repository    = { workspace = true }
-documentation = "https://docs.rs/eventsourced/latest/eventsourced"
+documentation = "https://docs.rs/eventsourced/latest/eventsourced/"
+publish       = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/justfile
+++ b/justfile
@@ -3,30 +3,31 @@ set shell := ["bash", "-uc"]
 nightly := `rustc --version | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | sed 's/^/nightly-/'`
 
 check:
-	cargo check --package eventsourced --all-features
-	cargo check --package eventsourced-nats
-	cargo check --package eventsourced-postgres
-	cargo check --package eventsourced-projection
+    cargo check --package eventsourced --all-features
+    cargo check --package eventsourced-nats
+    cargo check --package eventsourced-postgres
+    cargo check --package eventsourced-projection
 
 fix:
-	cargo fix --allow-dirty --allow-staged --all-features
+    cargo fix --allow-dirty --allow-staged --all-features
 
 fmt:
-	cargo +{{nightly}} fmt
+    cargo +{{ nightly }} fmt
+    RUST_LOG=error taplo fmt
 
 fmt-check:
-	cargo +{{nightly}} fmt --check
+    cargo +{{ nightly }} fmt --check
 
 lint:
-	cargo clippy --no-deps --all-features -- -D warnings
+    cargo clippy --no-deps --all-features -- -D warnings
 
 lint-fix:
-	cargo clippy --no-deps --all-features --fix --allow-dirty --allow-staged
+    cargo clippy --no-deps --all-features --fix --allow-dirty --allow-staged
 
 test:
-	cargo test --all-features
+    cargo test --all-features
 
 doc:
-	RUSTDOCFLAGS="-D warnings --cfg docsrs" cargo +{{nightly}} doc --no-deps --all-features
+    RUSTDOCFLAGS="-D warnings --cfg docsrs" cargo +{{ nightly }} doc --no-deps --all-features
 
 all: check fmt lint test doc


### PR DESCRIPTION
Standardize scaffolding, CI config, and package metadata to the shared template.

- `justfile`: 4-space indentation, `taplo fmt` in the `fmt` recipe
- `.gitignore`: canonical entries, sorted
- `Cargo.toml`: SPDX license, no `authors`, docs.rs `documentation`, consistent field order, explicit `publish`
- workflows / rustfmt edition aligned where applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)