### PR TITLE
test: pin Postgres containers to 18-alpine with explicit credentials

### DIFF
--- a/eventsourced-postgres/src/event_log.rs
+++ b/eventsourced-postgres/src/event_log.rs
@@ -428,17 +428,26 @@ mod tests {
     use eventsourced::{binarize, event_log::EventLog};
     use futures::{StreamExt, TryStreamExt};
     use std::{future, num::NonZeroU64};
-    use testcontainers::runners::AsyncRunner;
+    use testcontainers::{ImageExt, runners::AsyncRunner};
     use testcontainers_modules::postgres::Postgres;
     use uuid::Uuid;
 
     #[tokio::test]
     async fn test_event_log() -> Result<(), BoxError> {
-        let container = Postgres::default().with_host_auth().start().await?;
+        let container = Postgres::default()
+            .with_db_name("eventsourced")
+            .with_user("eventsourced")
+            .with_password("eventsourced")
+            .with_tag("18-alpine")
+            .start()
+            .await?;
         let port = container.get_host_port_ipv4(5432).await?;
 
         let config = PostgresEventLogConfig {
             port,
+            user: "eventsourced".to_string(),
+            password: "eventsourced".to_string(),
+            dbname: "eventsourced".to_string(),
             setup: true,
             ..Default::default()
         };

--- a/eventsourced-postgres/src/snapshot_store.rs
+++ b/eventsourced-postgres/src/snapshot_store.rs
@@ -195,17 +195,26 @@ mod tests {
     use crate::{PostgresSnapshotStore, PostgresSnapshotStoreConfig};
     use error_ext::BoxError;
     use eventsourced::{binarize, snapshot_store::SnapshotStore};
-    use testcontainers::runners::AsyncRunner;
+    use testcontainers::{ImageExt, runners::AsyncRunner};
     use testcontainers_modules::postgres::Postgres;
     use uuid::Uuid;
 
     #[tokio::test]
     async fn test_snapshot_store() -> Result<(), BoxError> {
-        let container = Postgres::default().with_host_auth().start().await?;
+        let container = Postgres::default()
+            .with_db_name("eventsourced")
+            .with_user("eventsourced")
+            .with_password("eventsourced")
+            .with_tag("18-alpine")
+            .start()
+            .await?;
         let port = container.get_host_port_ipv4(5432).await?;
 
         let config = PostgresSnapshotStoreConfig {
             port,
+            user: "eventsourced".to_string(),
+            password: "eventsourced".to_string(),
+            dbname: "eventsourced".to_string(),
             setup: true,
             ..Default::default()
         };

--- a/eventsourced-projection/src/postgres.rs
+++ b/eventsourced-projection/src/postgres.rs
@@ -390,7 +390,7 @@ mod tests {
 
     #[tokio::test]
     async fn test() -> Result<(), BoxError> {
-        let container = TCPostgres::default().with_tag("16-alpine").start().await?;
+        let container = TCPostgres::default().with_tag("18-alpine").start().await?;
         let port = container.get_host_port_ipv4(5432).await?;
 
         let cnn_url = format!("postgresql://postgres:postgres@localhost:{port}");


### PR DESCRIPTION
Standardizes the Postgres test containers to `18-alpine` and aligns credential handling.

- **`eventsourced-postgres`** (`event_log.rs`, `snapshot_store.rs`): replace `with_host_auth()` (which relied on `trust` auth because the config default password is empty) with explicit `with_db_name`/`with_user`/`with_password` (`"eventsourced"`), pinned to `18-alpine`. The test `Config` overrides `user`/`password`/`dbname` to match, mirroring how the eventbound tests are set up.
- **`eventsourced-projection`** (`postgres.rs`): bump the container tag from `16-alpine` to `18-alpine`.

Previously the untagged containers fell back to the `testcontainers-modules` 0.15 default, the EOL `postgres:11-alpine`.

Verified with `just all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)