### PR TITLE
docs: turn on warnings for missing docs

### DIFF
--- a/eventsourced-nats/src/event_log.rs
+++ b/eventsourced-nats/src/event_log.rs
@@ -222,16 +222,21 @@ where
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
+    /// The address of the NATS server.
     pub server_addr: String,
 
+    /// Optional authentication configuration.
     pub auth: Option<AuthConfig>,
 
+    /// The name of the event stream.
     #[serde(default = "event_stream_name_default")]
     pub event_stream_name: String,
 
+    /// The maximum size of the event stream in bytes.
     #[serde(default = "event_stream_max_bytes_default")]
     pub event_stream_max_bytes: i64,
 
+    /// Whether to create the event stream on startup.
     #[serde(default)]
     pub setup: bool,
 }

--- a/eventsourced-nats/src/lib.rs
+++ b/eventsourced-nats/src/lib.rs
@@ -1,6 +1,8 @@
 //! [EventLog](eventsourced::event_log::EventLog) and
 //! [SnapshotStore](eventsourced::snapshot_store::SnapshotStore) implementations based upon [NATS](https://nats.io/).
 
+#![warn(missing_docs)]
+
 mod event_log;
 mod snapshot_store;
 
@@ -19,16 +21,21 @@ use thiserror::Error;
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
 pub enum AuthConfig {
+    /// Authenticate with a user name and password.
     UserPassword {
+        /// The user name.
         user: String,
+        /// The password.
         password: SecretString,
     },
+    /// Authenticate with a NATS credentials file at the given path.
     CredentialsFile(PathBuf),
 }
 
 /// Errors from the [NatsEventLog] or [NatsSnapshotStore].
 #[derive(Debug, Error)]
 pub enum Error {
+    /// A NATS error occurred.
     #[error("NATS error: {0}")]
     Nats(String, #[source] Box<dyn std::error::Error + Send + Sync>),
 

--- a/eventsourced-nats/src/snapshot_store.rs
+++ b/eventsourced-nats/src/snapshot_store.rs
@@ -160,16 +160,21 @@ where
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
+    /// The address of the NATS server.
     pub server_addr: String,
 
+    /// Optional authentication configuration.
     pub auth: Option<AuthConfig>,
 
+    /// The name of the bucket.
     #[serde(default = "bucket_name_default")]
     pub bucket_name: String,
 
+    /// The maximum size of the bucket in bytes.
     #[serde(default = "bucket_max_bytes_default")]
     pub bucket_max_bytes: i64,
 
+    /// Whether to create the bucket on startup.
     #[serde(default)]
     pub setup: bool,
 }

--- a/eventsourced-postgres/src/event_log.rs
+++ b/eventsourced-postgres/src/event_log.rs
@@ -357,27 +357,37 @@ where
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
+    /// The host name of the Postgres server.
     pub host: String,
 
+    /// The port of the Postgres server.
     pub port: u16,
 
+    /// The user name used to connect.
     pub user: String,
 
+    /// The password used to connect.
     pub password: String,
 
+    /// The name of the database.
     pub dbname: String,
 
+    /// The SSL mode used to connect.
     pub sslmode: String,
 
+    /// The name of the events table.
     #[serde(default = "events_table_default")]
     pub events_table: String,
 
+    /// The interval at which the event log is polled for new events.
     #[serde(default = "poll_interval_default", with = "humantime_serde")]
     pub poll_interval: Duration,
 
+    /// The capacity of the broadcast channel for entity IDs.
     #[serde(default = "id_broadcast_capacity_default")]
     pub id_broadcast_capacity: NonZeroUsize,
 
+    /// Whether to create the database schema on startup.
     #[serde(default)]
     pub setup: bool,
 }

--- a/eventsourced-postgres/src/lib.rs
+++ b/eventsourced-postgres/src/lib.rs
@@ -1,6 +1,8 @@
 //! [EventLog](eventsourced::event_log::EventLog) and
 //! [SnapshotStore](eventsourced::snapshot_store::SnapshotStore) implementations based upon [PostgreSQL](https://www.postgresql.org/).
 
+#![warn(missing_docs)]
+
 mod event_log;
 mod snapshot_store;
 

--- a/eventsourced-postgres/src/snapshot_store.rs
+++ b/eventsourced-postgres/src/snapshot_store.rs
@@ -142,21 +142,29 @@ where
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
+    /// The host name of the Postgres server.
     pub host: String,
 
+    /// The port of the Postgres server.
     pub port: u16,
 
+    /// The user name used to connect.
     pub user: String,
 
+    /// The password used to connect.
     pub password: String,
 
+    /// The name of the database.
     pub dbname: String,
 
+    /// The SSL mode used to connect.
     pub sslmode: String,
 
+    /// The name of the snapshots table.
     #[serde(default = "snapshots_table_default")]
     pub snapshots_table: String,
 
+    /// Whether to create the database schema on startup.
     #[serde(default)]
     pub setup: bool,
 }

--- a/eventsourced-projection/src/lib.rs
+++ b/eventsourced-projection/src/lib.rs
@@ -1,1 +1,5 @@
+//! Read side projections for [eventsourced](https://docs.rs/eventsourced).
+
+#![warn(missing_docs)]
+
 pub mod postgres;

--- a/eventsourced-projection/src/postgres.rs
+++ b/eventsourced-projection/src/postgres.rs
@@ -1,3 +1,5 @@
+//! Projection of events to a Postgres database.
+
 use error_ext::StdErrorExt;
 use eventsourced::{binarize, event_log::EventLog};
 use futures::StreamExt;
@@ -27,6 +29,8 @@ pub struct Projection {
 }
 
 impl Projection {
+    /// Create and spawn a new [Projection] with the given name, event log, event handler and error
+    /// strategy, persisting its progress to the given Postgres pool.
     pub async fn new<E, L, H>(
         type_name: &'static str,
         name: String,
@@ -123,14 +127,17 @@ impl Projection {
         Ok(Projection { name, command_in })
     }
 
+    /// Run the projection and return its resulting [State].
     pub async fn run(&self) -> Result<State, CommandError> {
         self.dispatch_command(Command::Run).await
     }
 
+    /// Stop the projection and return its resulting [State].
     pub async fn stop(&self) -> Result<State, CommandError> {
         self.dispatch_command(Command::Stop).await
     }
 
+    /// Return the current [State] of the projection.
     pub async fn get_state(&self) -> Result<State, CommandError> {
         self.dispatch_command(Command::GetState).await
     }
@@ -148,10 +155,13 @@ impl Projection {
     }
 }
 
+/// Handler applying projected events to a Postgres database.
 #[trait_variant::make(Send)]
 pub trait EventHandler<E> {
+    /// The error type.
     type Error: StdError + Send + Sync + 'static;
 
+    /// Handle the given event within the given database transaction.
     async fn handle_event(
         &self,
         event: E,
@@ -159,15 +169,19 @@ pub trait EventHandler<E> {
     ) -> Result<(), Self::Error>;
 }
 
+/// Error creating a [Projection].
 #[derive(Debug, Error)]
 pub enum Error {
+    /// Loading the state from the database failed.
     #[error("cannot create Projection, b/c cannot load state from database")]
     Sqlx(#[from] sqlx::Error),
 
+    /// Converting the loaded sequence number into a non-zero value failed.
     #[error("cannot create Projection, b/c cannot convert loaded seq_no into non zero value")]
     TryFromInt(#[from] TryFromIntError),
 }
 
+/// Error dispatching a command to a [Projection].
 #[derive(Debug, Error, Serialize, Deserialize)]
 pub enum CommandError {
     /// The command cannot be sent from this [Projection] to its projection.
@@ -179,23 +193,34 @@ pub enum CommandError {
     ReceiveResponse(Command, String),
 }
 
+/// Strategy for handling an error raised by the event handler.
 #[derive(Debug, Clone, Copy)]
 pub enum ErrorStrategy {
+    /// Retry after the given duration.
     Retry(Duration),
+    /// Stop the projection.
     Stop,
 }
 
+/// The state of a [Projection].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct State {
+    /// The sequence number of the last handled event, if any.
     pub seq_no: Option<NonZeroU64>,
+    /// Whether the projection is currently running.
     pub running: bool,
+    /// The last error, if any.
     pub error: Option<String>,
 }
 
+/// A command for a [Projection].
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum Command {
+    /// Run the projection.
     Run,
+    /// Stop the projection.
     Stop,
+    /// Get the current [State].
     GetState,
 }
 

--- a/eventsourced/src/binarize.rs
+++ b/eventsourced/src/binarize.rs
@@ -13,10 +13,14 @@ pub mod serde_json;
 
 /// Conversion to and from `Bytes`.
 pub trait Binarize<E, S>: Copy + Send + Sync + 'static {
+    /// Error converting an event to bytes.
     type EventToBytesError: StdError + Send + Sync + 'static;
+    /// Error converting bytes to an event.
     type EventFromBytesError: StdError + Send + Sync + 'static;
 
+    /// Error converting state to bytes.
     type StateToBytesError: StdError + Send + Sync + 'static;
+    /// Error converting bytes to state.
     type StateFromBytesError: StdError + Send + Sync + 'static;
 
     /// Convert an event to bytes.

--- a/eventsourced/src/binarize/prost.rs
+++ b/eventsourced/src/binarize/prost.rs
@@ -5,6 +5,7 @@ use crate::binarize::Binarize;
 use bytes::{Bytes, BytesMut};
 use prost::{DecodeError, EncodeError, Message};
 
+/// A [Binarize] implementation for any [Message], based upon prost.
 #[derive(Debug, Clone, Copy)]
 pub struct ProstBinarize;
 
@@ -36,6 +37,7 @@ where
     }
 }
 
+/// Encode the given [Message] to [Bytes].
 pub fn to_bytes<T>(value: &T) -> Result<Bytes, EncodeError>
 where
     T: Message,
@@ -45,6 +47,7 @@ where
     Ok(bytes.into())
 }
 
+/// Decode the given [Bytes] into a [Message].
 pub fn from_bytes<T>(bytes: Bytes) -> Result<T, DecodeError>
 where
     T: Message + Default,

--- a/eventsourced/src/binarize/serde_json.rs
+++ b/eventsourced/src/binarize/serde_json.rs
@@ -6,6 +6,8 @@ use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use serde_json::{Error, from_slice, to_value};
 
+/// A [Binarize] implementation based upon serde_json, for any type that is [Serialize] and
+/// [Deserialize].
 #[derive(Debug, Clone, Copy)]
 pub struct SerdeJsonBinarize;
 
@@ -37,6 +39,7 @@ where
     }
 }
 
+/// Serialize the given value to JSON [Bytes].
 pub fn to_bytes<T>(value: &T) -> Result<Bytes, Error>
 where
     T: Serialize,
@@ -44,6 +47,7 @@ where
     to_value(value).map(|value| value.to_string().into())
 }
 
+/// Deserialize a value from the given JSON [Bytes].
 pub fn from_bytes<T>(bytes: Bytes) -> Result<T, Error>
 where
     for<'de> T: Deserialize<'de>,

--- a/eventsourced/src/event_log.rs
+++ b/eventsourced/src/event_log.rs
@@ -13,8 +13,10 @@ pub trait EventLog
 where
     Self: Clone + 'static,
 {
+    /// The type of entity IDs.
     type Id: Debug;
 
+    /// The error type.
     type Error: StdError + Send + Sync + 'static;
 
     /// The maximum value for sequence numbers. Defaults to `NonZeroU64::MAX` unless overriden by an

--- a/eventsourced/src/event_log/test.rs
+++ b/eventsourced/src/event_log/test.rs
@@ -1,3 +1,5 @@
+//! A [TestEventLog], useful for testing.
+
 use crate::EventLog;
 use bytes::Bytes;
 use error_ext::BoxError;
@@ -153,6 +155,7 @@ where
     }
 }
 
+/// Error of the [TestEventLog].
 #[derive(Debug, Error)]
 #[error(transparent)]
 pub struct Error(BoxError);

--- a/eventsourced/src/lib.rs
+++ b/eventsourced/src/lib.rs
@@ -54,6 +54,8 @@
 //! build read side projections. There is early support for projections in the
 //! `eventsourced-projection` crate.
 
+#![warn(missing_docs)]
+
 pub mod binarize;
 pub mod event_log;
 pub mod snapshot_store;
@@ -136,8 +138,11 @@ pub enum CommandEffect<E, Reply, Error>
 where
     E: EventSourced,
 {
+    /// Emit and persist an event, then build a reply from the resulting state.
     EmitAndReply(E::Event, Box<dyn FnOnce(&E) -> Reply + Send + Sync>),
+    /// Reply without emitting an event.
     Reply(Reply),
+    /// Reject the command with an error.
     Reject(Error),
 }
 
@@ -415,18 +420,23 @@ pub struct HandleCommandError(String);
 /// A technical error when spawning an [EventSourcedEntity].
 #[derive(Debug, Error)]
 pub enum SpawnError {
+    /// Loading the snapshot from the snapshot store failed.
     #[error("cannot load snapshot from snapshot store")]
     LoadSnapshot(#[source] BoxError),
 
+    /// The last sequence number is less than the snapshot sequence number.
     #[error("last sequence number {0:?} less than snapshot sequence number {0:?}")]
     InvalidLastSeqNo(Option<NonZeroU64>, Option<NonZeroU64>),
 
+    /// Getting the last sequence number from the event log failed.
     #[error("cannot get last seqence number from event log")]
     LastNonZeroU64(#[source] BoxError),
 
+    /// Getting the events-by-ID stream from the event log failed.
     #[error("cannot get events by ID stream from event log")]
     EventsById(#[source] BoxError),
 
+    /// Getting the next event from the events-by-ID stream failed.
     #[error("cannot get next event from events by ID stream")]
     NextEvent(#[source] BoxError),
 }

--- a/eventsourced/src/snapshot_store.rs
+++ b/eventsourced/src/snapshot_store.rs
@@ -13,8 +13,10 @@ pub trait SnapshotStore
 where
     Self: Clone + 'static,
 {
+    /// The type of entity IDs.
     type Id: Debug;
 
+    /// The error type.
     type Error: StdError + Send + Sync + 'static;
 
     /// Save the given snapshot state for the given entity ID and sequence number.
@@ -44,7 +46,9 @@ where
 /// Snapshot state along with its sequence number.
 #[derive(Debug)]
 pub struct Snapshot<S> {
+    /// The sequence number of the snapshotted state.
     pub seq_no: NonZeroU64,
+    /// The snapshotted state.
     pub state: S,
 }
 

--- a/eventsourced/src/snapshot_store/noop.rs
+++ b/eventsourced/src/snapshot_store/noop.rs
@@ -11,6 +11,7 @@ use std::{
 pub struct NoopSnapshotStore<I>(PhantomData<I>);
 
 impl<I> NoopSnapshotStore<I> {
+    /// Create a new [NoopSnapshotStore].
     pub fn new() -> Self {
         Default::default()
     }

--- a/eventsourced/src/snapshot_store/test.rs
+++ b/eventsourced/src/snapshot_store/test.rs
@@ -1,3 +1,5 @@
+//! A [TestSnapshotStore], useful for testing.
+
 use crate::snapshot_store::{Snapshot, SnapshotStore};
 use bytes::Bytes;
 use error_ext::BoxError;
@@ -64,6 +66,7 @@ where
     }
 }
 
+/// Error of the [TestSnapshotStore].
 #[derive(Debug, Error)]
 #[error(transparent)]
 pub struct Error(BoxError);


### PR DESCRIPTION
Enables `#![warn(missing_docs)]` across all crates and adds doc comments for the public items the lint surfaced (incl. a missing crate-level doc on eventsourced-projection).